### PR TITLE
Useful error against multiple clauses

### DIFF
--- a/rb/lib/selenium/webdriver/common/search_context.rb
+++ b/rb/lib/selenium/webdriver/common/search_context.rb
@@ -95,6 +95,9 @@ module Selenium
           args
         when 1
           arg = args.first
+          unless arg.size == 1
+            raise ArgumentError, "Expected only one clause in #{arg}, found #{arg.size}"
+          end
 
           unless arg.respond_to?(:shift)
             raise ArgumentError, "expected #{arg.inspect}:#{arg.class} to respond to #shift"


### PR DESCRIPTION
...because this is an easy mistake to make when the interface invites multiple clauses, and silent failure is evil.
